### PR TITLE
fix: workflow triggers and git push error handling

### DIFF
--- a/.github/workflows/wf1_daily_ingest.yml
+++ b/.github/workflows/wf1_daily_ingest.yml
@@ -2,13 +2,17 @@ name: WF1 - Daily Ingest
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
+
+concurrency:
+  group: wf1-${{ github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
   ingest:
     # Only run for repository collaborators/owner to prevent API abuse
     if: |
-      contains(github.event.issue.labels.*.name, 'veille') &&
+      github.event.label.name == 'veille' &&
       (github.event.issue.author_association == 'OWNER' ||
        github.event.issue.author_association == 'COLLABORATOR' ||
        github.event.issue.author_association == 'MEMBER')
@@ -19,8 +23,11 @@ jobs:
       issues: write
     
     steps:
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.github/workflows/wf3_deep_research.yml
+++ b/.github/workflows/wf3_deep_research.yml
@@ -2,13 +2,17 @@ name: WF3 - Deep Research
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
+
+concurrency:
+  group: wf3-${{ github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
   research:
     # Only run for repository collaborators/owner to prevent API abuse
     if: |
-      contains(github.event.issue.labels.*.name, 'research') &&
+      github.event.label.name == 'research' &&
       (github.event.issue.author_association == 'OWNER' ||
        github.event.issue.author_association == 'COLLABORATOR' ||
        github.event.issue.author_association == 'MEMBER')
@@ -19,8 +23,11 @@ jobs:
       issues: write
     
     steps:
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/src/utils/git_ops.py
+++ b/src/utils/git_ops.py
@@ -1,33 +1,44 @@
-import os
+import subprocess
 from tenacity import retry, stop_after_attempt, wait_fixed
+
+
+def run_cmd(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    """Run command with proper error capture."""
+    print(f"🔧 Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0 and check:
+        print(f"❌ STDOUT: {result.stdout}")
+        print(f"❌ STDERR: {result.stderr}")
+        raise Exception(f"Command failed: {' '.join(cmd)}")
+    return result
+
 
 @retry(stop=stop_after_attempt(3), wait=wait_fixed(2))
 def safe_commit(files, message):
     """
-    Commits files with retry logic to handle race conditions
+    Commits files with retry logic to handle race conditions.
+    Uses subprocess for better error visibility.
     """
-    # Configure git if needed (usually done by actions/checkout but good to be safe)
-    os.system('git config user.name "ResearchOps Bot"')
-    os.system('git config user.email "bot@researchops.local"')
-    
+    # Configure git
+    run_cmd(["git", "config", "user.name", "ResearchOps Bot"])
+    run_cmd(["git", "config", "user.email", "bot@researchops.local"])
+
     # Pull latest changes to avoid conflicts
-    if os.system("git pull --rebase") != 0:
-        raise Exception("Git pull failed")
-    
+    run_cmd(["git", "pull", "--rebase"])
+
     # Add files
     for f in files:
-        if os.system(f'git add "{f}"') != 0:
-             raise Exception(f"Git add failed for {f}")
-    
+        run_cmd(["git", "add", f])
+
+    # Check if there are changes to commit
+    status = run_cmd(["git", "status", "--porcelain"], check=False)
+    if not status.stdout.strip():
+        print("ℹ️ Nothing to commit")
+        return
+
     # Commit
-    if os.system(f'git commit -m "{message}"') != 0:
-        # Check if there are changes to commit
-        status = os.popen("git status --porcelain").read()
-        if not status:
-            print("Nothing to commit")
-            return
-        raise Exception("Git commit failed")
-    
+    run_cmd(["git", "commit", "-m", message])
+
     # Push
-    if os.system("git push") != 0:
-        raise Exception("Git push failed")
+    run_cmd(["git", "push"])
+    print("✅ Pushed successfully")


### PR DESCRIPTION
- Change triggers from [opened, labeled] to [labeled] only
- Use github.event.label.name for precise label matching
- Add concurrency control to prevent race conditions
- Upgrade to actions/checkout@v4 with explicit token
- Replace os.system with subprocess for better error visibility
- Add fetch-depth: 0 for full git history